### PR TITLE
Avoid PlantUML syntax error (from release 1.2023.2)

### DIFF
--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -543,6 +543,8 @@ class uml_emitter:
         if  pre is not None:
             self.thismod_prefix = pre.arg
 
+        fd.write('package \"%s:%s\" as %s_%s { \n' %(self.thismod_prefix, pkg, self.make_plantuml_keyword(self.thismod_prefix), self.make_plantuml_keyword(pkg)))
+        fd.write('} \n')
 
         # print package for this module and a class to represent module (notifs and rpcs)
         # print module info as note


### PR DESCRIPTION
Avoid PlantUML syntax error by defining an empty package before defining the note with annotations on top of package (from 1.2023.2 PlantUML has stricter syntax requiring packages be defined before referencing them, e.g., in a note.