### PR TITLE
Improve info message when a uses reference is skipped in UML Plugin

### DIFF
--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -1063,7 +1063,7 @@ class uml_emitter:
                     # Grouping in other module, use red...
                     # fd.write('class \"%s\" as %s << (G,Red) grouping>>\n' %(self.uses_as_string[u], self.make_plantuml_keyword(self.uses_as_string[u])))
                     # fd.write('%s --> %s : uses \n' %(p, self.make_plantuml_keyword(self.uses_as_string[u])))
-                    sys.stderr.write("Info: Skipping uses reference to %s, grouping not in input files \n" %p)
+                    sys.stderr.write("Info: Skipping uses reference to %s, grouping not in input files \n" %self.uses_as_string[u])
                     pass
 
         if self.ctx_leafrefs: # TODO correct paths for external leafrefs

--- a/pyang/plugins/uml.py
+++ b/pyang/plugins/uml.py
@@ -739,7 +739,7 @@ class uml_emitter:
         self.uses.append([p,u])
         self.uses_as_string[u] = node.arg
 
-    def emit_grouping(self, module, stmt, fd, glob = 'False'):
+    def emit_grouping(self, module, stmt, fd, glob = False):
         if not self.ctx_filterfile:
             # MEF
             # When referenced from this module


### PR DESCRIPTION
When a module uses a grouping in an imported module that is not in the list of input files, the uses reference to that grouping cannot be rendered.

When this occurs the UML Plugin issues an info message indicating that the reference to a grouping has been skipped using the PlantUML keyword of the parent node of the uses statement rather than the more understandable actual name of the grouping. It would be expected that PlantUML keywords would be cryptic to most users who are not interested in the details of the PlantUML code. 

This pull request modifies this info message to quote the name of the grouping. The change can be verified using ietf-yang-patch@2017-02-22 as an example.

If module ietf-yang-patch@2017-02-22 is the only input file and the UML as the output format is selected, then without the modification in this pull request the following is output:
```
Info: Skipping uses reference to ietf_yang_patch_I_yang_patch_status_I_yang_patch_status_I_global_status_I_global_errors_case, grouping not in input files 
Info: Skipping uses reference to ietf_yang_patch_I_yang_patch_status_I_yang_patch_status_I_edit_status_I_edit_I_edit_status_choice_I_errors_case, grouping not in input files 

Process finished with exit code 0
```

And with the modification:
```
Info: Skipping uses reference to rc:errors, grouping not in input files 
Info: Skipping uses reference to rc:errors, grouping not in input files 

Process finished with exit code 0
```

Note that this pull request corrects an incorrect type assignment in the definition of the function emit_grouping.